### PR TITLE
Socket ioctl

### DIFF
--- a/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
+++ b/book/src/kernel/linux-compatibility/syscall-flag-coverage/file-descriptor-and-io-control/ioctl.scml
@@ -4,6 +4,10 @@ tty_ops = TCGETS | TCSETS | TCSETSW | TCSETSF | TCGETS2 | TCSETS2 |
           KDGKBMODE;
 term_ops = TIOCGPGRP | TIOCSPGRP | TIOCSCTTY | TIOCNOTTY | TIOCGSID;
 pty_master_ops = TIOCSPTLCK | TIOCGPTLCK | TIOCGPTPEER | TIOCPKT | TIOCGPKT;
+socket_ops = SIOCGIFNAME | SIOCGIFCONF | SIOCGIFFLAGS |
+             SIOCGIFMETRIC | SIOCGIFMTU | SIOCGIFHWADDR |
+             SIOCGIFINDEX | SIOCGIFTXQLEN | SIOCGIFADDR |
+             SIOCGIFDSTADDR | SIOCGIFBRDADDR | SIOCGIFNETMASK;
 
 // Control file descriptor flags and I/O modes
 ioctl(fd, op = FIONCLEX | FIOCLEX | FIONBIO | FIOASYNC, ..);
@@ -32,3 +36,6 @@ ioctl(fd, op = BLKGETSIZE64 | BLKSSZGET, ..);
 
 // Control Trust Domain Extensions (TDX) guest devices
 ioctl(fd, op = TDX_CMD_GET_REPORT0, ..);
+
+// Control socket and network interface settings
+ioctl(fd, op = <socket_ops>, ..);

--- a/kernel/src/net/iface/mod.rs
+++ b/kernel/src/net/iface/mod.rs
@@ -19,3 +19,12 @@ pub type RawTcpSocketExt = aster_bigtcp::socket::RawTcpSocketExt<ext::BigtcpExt>
 pub type TcpConnection = aster_bigtcp::socket::TcpConnection<ext::BigtcpExt>;
 pub type TcpListener = aster_bigtcp::socket::TcpListener<ext::BigtcpExt>;
 pub type UdpSocket = aster_bigtcp::socket::UdpSocket<ext::BigtcpExt>;
+
+/// The default transmit queue length.
+///
+/// On Linux, this value limits the number of SKBs
+/// that can be queued in a network device's egress qdisc.
+/// This value does not take effect on Asterinas now.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/net/pkt_sched.h#L13>.
+pub(super) const DEFAULT_TX_QUEUE_LEN: u32 = 1000;

--- a/kernel/src/net/socket/ip/datagram/mod.rs
+++ b/kernel/src/net/socket/ip/datagram/mod.rs
@@ -4,7 +4,7 @@ use aster_bigtcp::wire::IpEndpoint;
 use bound::BoundDatagram;
 use unbound::{BindOptions, UnboundDatagram};
 
-use super::addr::UNSPECIFIED_LOCAL_ENDPOINT;
+use super::{addr::UNSPECIFIED_LOCAL_ENDPOINT, ioctl::ipv4_ioctl};
 use crate::{
     events::IoEvents,
     fs::{
@@ -29,7 +29,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
-    util::{MultiRead, MultiWrite, net::SockType},
+    util::{MultiRead, MultiWrite, ioctl::RawIoctl, net::SockType},
 };
 
 mod bound;
@@ -137,6 +137,14 @@ impl Pollable for DatagramSocket {
 impl SocketPrivate for DatagramSocket {
     fn is_nonblocking(&self) -> bool {
         self.common.is_nonblocking()
+    }
+
+    fn protocol_ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        // Handle common IPv4/IPv6 ioctl commands.
+        // TODO: Handle IPv6 ioctls once UDP sockets support IPv6.
+        ipv4_ioctl(raw_ioctl)
+
+        // Handle ioctl commands that require UDP-specific handling.
     }
 }
 

--- a/kernel/src/net/socket/ip/ioctl.rs
+++ b/kernel/src/net/socket/ip/ioctl.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_bigtcp::{iface::InterfaceFlags, wire::Ipv4Address};
+
+use crate::{
+    net::socket::util::ioctl::CIfReq,
+    prelude::*,
+    util::ioctl::{RawIoctl, dispatch_ioctl},
+};
+
+mod ioctl_defs {
+    use super::CIfReq;
+    use crate::util::ioctl::{InOutData, ioc};
+
+    // Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/sockios.h#L62>.
+    pub(super) type GetIfAddr    = ioc!(SIOCGIFADDR,    0x8915, InOutData<CIfReq>);
+    pub(super) type GetIfDstAddr = ioc!(SIOCGIFDSTADDR, 0x8917, InOutData<CIfReq>);
+    pub(super) type GetIfBrdAddr = ioc!(SIOCGIFBRDADDR, 0x8919, InOutData<CIfReq>);
+    pub(super) type GetIfNetmask = ioc!(SIOCGIFNETMASK, 0x891B, InOutData<CIfReq>);
+}
+
+pub(super) fn ipv4_ioctl(raw_ioctl: RawIoctl) -> Result<i32> {
+    use ioctl_defs::*;
+
+    dispatch_ioctl!(match raw_ioctl {
+        cmd @ GetIfAddr => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            let address = iface
+                .ipv4_cidr()
+                .ok_or_else(|| Error::with_message(Errno::EADDRNOTAVAIL, "no IPv4 address found"))?
+                .address();
+            ifreq.set_sockaddr_ipv4(address);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfDstAddr => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            // Asterinas does not yet support point-to-point interfaces,
+            // so we report the local IPv4 address instead, consistent with Linux's behavior.
+            let address = iface
+                .ipv4_cidr()
+                .ok_or_else(|| Error::with_message(Errno::EADDRNOTAVAIL, "no IPv4 address found"))?
+                .address();
+            ifreq.set_sockaddr_ipv4(address);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfBrdAddr => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            let address = if iface.flags().contains(InterfaceFlags::BROADCAST)
+                && let Some(broadcast_addr) = iface.broadcast_addr()
+            {
+                broadcast_addr
+            } else {
+                Ipv4Address::UNSPECIFIED
+            };
+            ifreq.set_sockaddr_ipv4(address);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfNetmask => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            let netmask = iface
+                .ipv4_cidr()
+                .ok_or_else(|| Error::with_message(Errno::EADDRNOTAVAIL, "no IPv4 address found"))?
+                .netmask();
+            ifreq.set_sockaddr_ipv4(netmask);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        _ => return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown"),
+    })
+}

--- a/kernel/src/net/socket/ip/mod.rs
+++ b/kernel/src/net/socket/ip/mod.rs
@@ -3,6 +3,7 @@
 mod addr;
 mod common;
 mod datagram;
+mod ioctl;
 pub mod options;
 mod stream;
 

--- a/kernel/src/net/socket/ip/stream/connecting.rs
+++ b/kernel/src/net/socket/ip/stream/connecting.rs
@@ -9,10 +9,7 @@ use aster_bigtcp::{
 use super::{connected::ConnectedStream, init::InitStream, observer::StreamObserver};
 use crate::{
     events::IoEvents,
-    net::{
-        iface::{BoundTcpPort, Iface, TcpConnection},
-        socket::ip::IpAddressFamily,
-    },
+    net::iface::{BoundTcpPort, Iface, TcpConnection},
     prelude::*,
 };
 
@@ -87,8 +84,7 @@ impl ConnectingStream {
             )),
             ConnectState::Refused => {
                 let bound_port = self.tcp_conn.into_bound_port().unwrap();
-                let family = IpAddressFamily::from(*bound_port.addr());
-                ConnResult::Refused(InitStream::new_refused(bound_port, family))
+                ConnResult::Refused(InitStream::new_refused(bound_port))
             }
         }
     }

--- a/kernel/src/net/socket/ip/stream/init.rs
+++ b/kernel/src/net/socket/ip/stream/init.rs
@@ -25,11 +25,6 @@ use crate::{
 
 pub(super) struct InitStream {
     bound_port: Option<BoundTcpPort>,
-    /// The address family of this socket (IPv4 or IPv6).
-    //
-    // TODO: Encode the address family in the type system (e.g., `InitStream<IPv4Family>`)
-    // so that type mismatches are caught at compile time instead of runtime.
-    family: IpAddressFamily,
     /// Indicates if the last `connect()` is considered to be done.
     ///
     /// If `connect()` is called but we're still in the `InitStream`, this means that the
@@ -53,46 +48,43 @@ pub(super) struct InitStream {
 }
 
 impl InitStream {
-    pub(super) fn new(family: IpAddressFamily) -> Self {
+    pub(super) fn new() -> Self {
         Self {
             bound_port: None,
-            family,
             is_connect_done: true,
             is_conn_refused: AtomicBool::new(false),
         }
     }
 
-    pub(super) fn new_bound(bound_port: BoundTcpPort, family: IpAddressFamily) -> Self {
+    pub(super) fn new_bound(bound_port: BoundTcpPort) -> Self {
         Self {
             bound_port: Some(bound_port),
-            family,
             is_connect_done: true,
             is_conn_refused: AtomicBool::new(false),
         }
     }
 
-    pub(super) fn new_refused(bound_port: BoundTcpPort, family: IpAddressFamily) -> Self {
+    pub(super) fn new_refused(bound_port: BoundTcpPort) -> Self {
         Self {
             bound_port: Some(bound_port),
-            family,
             is_connect_done: false,
             is_conn_refused: AtomicBool::new(true),
         }
     }
 
-    /// Returns the address family of this socket.
-    pub(super) fn family(&self) -> IpAddressFamily {
-        self.family
-    }
-
-    pub(super) fn bind(&mut self, endpoint: &IpEndpoint, can_reuse: bool) -> Result<()> {
+    pub(super) fn bind(
+        &mut self,
+        endpoint: &IpEndpoint,
+        family: IpAddressFamily,
+        can_reuse: bool,
+    ) -> Result<()> {
         if self.bound_port.is_some() {
             return_errno_with_message!(Errno::EINVAL, "the socket is already bound to an address");
         }
 
         // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
         // IPv6 addresses.
-        if IpAddressFamily::from(endpoint.addr) != self.family {
+        if IpAddressFamily::from(endpoint.addr) != family {
             return_errno_with_message!(
                 Errno::EAFNOSUPPORT,
                 "the protocol family does not match the address family"
@@ -111,6 +103,7 @@ impl InitStream {
     pub(super) fn connect(
         self,
         remote_endpoint: &IpEndpoint,
+        family: IpAddressFamily,
         option: &RawTcpOption,
         can_reuse: bool,
         observer: StreamObserver,
@@ -122,7 +115,7 @@ impl InitStream {
 
         // When we support `IPV6_V6ONLY` and if it is set, we should also reject IPv4-mapped
         // IPv6 addresses.
-        if IpAddressFamily::from(remote_endpoint.addr) != self.family {
+        if IpAddressFamily::from(remote_endpoint.addr) != family {
             return Err((
                 Error::with_message(
                     Errno::EAFNOSUPPORT,
@@ -156,9 +149,9 @@ impl InitStream {
         ConnectingStream::new(bound_port, *remote_endpoint, option, observer).map_err(
             |(err, bound_port)| {
                 if err.error() == Errno::ECONNREFUSED {
-                    (err, InitStream::new_refused(bound_port, self.family))
+                    (err, InitStream::new_refused(bound_port))
                 } else {
-                    (err, InitStream::new_bound(bound_port, self.family))
+                    (err, InitStream::new_bound(bound_port))
                 }
             },
         )
@@ -213,7 +206,7 @@ impl InitStream {
 
         match ListenStream::new(bound_port, backlog, option, observer) {
             Ok(listen_stream) => Ok(listen_stream),
-            Err((bound_port, error)) => Err((error, Self::new_bound(bound_port, self.family))),
+            Err((bound_port, error)) => Err((error, Self::new_bound(bound_port))),
         }
     }
 

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -63,6 +63,7 @@ pub struct StreamSocket {
     // FIXME: We perform userspace reads/writes when holding the spin locks (e.g., this state lock
     // and other locks in `aster-bigtcp`), which will break the atomic mode.
     state: RwLock<Takeable<State>>,
+    family: IpAddressFamily,
     options: RwLock<OptionSet>,
     timeouts: SocketTimeouts,
 
@@ -108,7 +109,7 @@ impl OptionSet {
 
 impl StreamSocket {
     pub fn new(is_nonblocking: bool, family: IpAddressFamily) -> Arc<Self> {
-        let init_stream = InitStream::new(family);
+        let init_stream = InitStream::new();
         let status_flags = if is_nonblocking {
             StatusFlags::O_NONBLOCK
         } else {
@@ -116,6 +117,7 @@ impl StreamSocket {
         };
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Init(init_stream))),
+            family,
             options: RwLock::new(OptionSet::new()),
             timeouts: SocketTimeouts::new(),
             pollee: Pollee::new(),
@@ -125,6 +127,7 @@ impl StreamSocket {
 
     fn new_accepted(
         connected_stream: ConnectedStream,
+        family: IpAddressFamily,
         listener_options: &OptionSet,
         listener_timeouts: &SocketTimeouts,
         is_nonblocking: bool,
@@ -171,6 +174,7 @@ impl StreamSocket {
 
         Arc::new(Self {
             state: RwLock::new(Takeable::new(State::Connected(connected_stream))),
+            family,
             options: RwLock::new(options),
             timeouts: listener_timeouts.clone(),
             pollee,
@@ -276,6 +280,7 @@ impl StreamSocket {
 
             let (target_state, iface_to_poll) = match init_stream.connect(
                 remote_endpoint,
+                self.family,
                 &raw_option,
                 options.socket.reuse_addr(),
                 StreamObserver::new(self.pollee.clone()),
@@ -343,6 +348,7 @@ impl StreamSocket {
             let listener_options = self.options.read();
             let accepted_socket = Self::new_accepted(
                 connected_stream,
+                self.family,
                 &listener_options,
                 &self.timeouts,
                 is_nonblocking,
@@ -476,7 +482,7 @@ impl Socket for StreamSocket {
         };
 
         let can_reuse = self.options.read().socket.reuse_addr();
-        init_stream.bind(&endpoint, can_reuse)
+        init_stream.bind(&endpoint, self.family, can_reuse)
     }
 
     fn connect(&self, socket_addr: SocketAddr) -> Result<()> {
@@ -566,7 +572,7 @@ impl Socket for StreamSocket {
         let local_endpoint = match state.as_ref() {
             State::Init(init_stream) => init_stream
                 .local_endpoint()
-                .unwrap_or_else(|| init_stream.family().unspecified_endpoint()),
+                .unwrap_or_else(|| self.family.unspecified_endpoint()),
             State::Connecting(connecting_stream) => connecting_stream.local_endpoint(),
             State::Listen(listen_stream) => listen_stream.local_endpoint(),
             State::Connected(connected_stream) => connected_stream.local_endpoint(),

--- a/kernel/src/net/socket/ip/stream/mod.rs
+++ b/kernel/src/net/socket/ip/stream/mod.rs
@@ -20,6 +20,7 @@ use util::{Retrans, TcpOptionSet};
 
 use super::{
     addr::IpAddressFamily,
+    ioctl::ipv4_ioctl,
     options::{IpOptionSet, SetIpLevelOption},
 };
 use crate::{
@@ -47,7 +48,7 @@ use crate::{
     },
     prelude::*,
     process::signal::{PollHandle, Pollable, Pollee},
-    util::{MultiRead, MultiWrite, net::SockType},
+    util::{MultiRead, MultiWrite, ioctl::RawIoctl, net::SockType},
 };
 
 mod connected;
@@ -469,6 +470,18 @@ impl Pollable for StreamSocket {
 impl SocketPrivate for StreamSocket {
     fn is_nonblocking(&self) -> bool {
         self.common.is_nonblocking()
+    }
+
+    fn protocol_ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        // Handle common IPv4/IPv6 ioctl commands.
+        match self.family {
+            IpAddressFamily::IPv4 => ipv4_ioctl(raw_ioctl),
+            IpAddressFamily::IPv6 => {
+                return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown")
+            }
+        }
+
+        // Handle ioctl commands that require TCP-specific handling.
     }
 }
 

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -13,8 +13,9 @@ use crate::{
         },
         pseudofs::SockFs,
     },
+    net::socket::util::ioctl::socket_ioctl,
     prelude::*,
-    util::{MultiRead, MultiWrite},
+    util::{MultiRead, MultiWrite, ioctl::RawIoctl},
 };
 
 pub mod ip;
@@ -27,7 +28,7 @@ pub mod vsock;
 mod private {
     use core::time::Duration;
 
-    use crate::{events::IoEvents, prelude::*, process::signal::Pollable};
+    use crate::{events::IoEvents, prelude::*, process::signal::Pollable, util::ioctl::RawIoctl};
 
     /// Common methods for sockets, but private to the network module.
     ///
@@ -65,6 +66,11 @@ mod private {
                         _ => err,
                     })
             }
+        }
+
+        /// Handles commands specific to its protocol or socket type.
+        fn protocol_ioctl(&self, _raw_ioctl: RawIoctl) -> Result<i32> {
+            return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown");
         }
     }
 }
@@ -159,6 +165,10 @@ impl<T: Socket + 'static> FileLike for T {
             MessageHeader::new(None, Vec::new()),
             SendFlags::empty(),
         )
+    }
+
+    fn ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
+        socket_ioctl(self, raw_ioctl)
     }
 
     fn settable_status_flags(&self) -> SettableStatusFlags {

--- a/kernel/src/net/socket/netlink/route/kernel/link.rs
+++ b/kernel/src/net/socket/netlink/route/kernel/link.rs
@@ -10,7 +10,7 @@ use aster_bigtcp::{iface::InterfaceType, wire::EthernetAddress};
 use super::util::finish_response;
 use crate::{
     net::{
-        iface::{Iface, iter_all_ifaces},
+        iface::{DEFAULT_TX_QUEUE_LEN, Iface, iter_all_ifaces},
         socket::netlink::{
             message::{CMsgSegHdr, CSegmentType, GetRequestFlags, SegHdrCommonFlags},
             route::message::{LinkAttr, LinkSegment, LinkSegmentBody, RtnlSegment},
@@ -22,15 +22,6 @@ use crate::{
 
 /// The unspecified link-layer address.
 const UNSPECIFIED_LINK_ADDR: EthernetAddress = EthernetAddress([0; 6]);
-
-/// The default transmit queue length.
-///
-/// On Linux, this value limits the number of SKBs
-/// that can be queued in a network device's egress qdisc.
-/// This value does not take effect on Asterinas now.
-///
-/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/net/pkt_sched.h#L13>.
-const DEFAULT_TX_QUEUE_LEN: u32 = 1000;
 
 pub(super) fn do_get_link(request_segment: &LinkSegment) -> Result<Vec<RtnlSegment>> {
     let filter_by = FilterBy::from_request(request_segment)?;

--- a/kernel/src/net/socket/util/ioctl.rs
+++ b/kernel/src/net/socket/util/ioctl.rs
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MPL-2.0
+
+use aster_bigtcp::wire::Ipv4Address;
+use ostd::task::Task;
+
+use crate::{
+    net::{
+        iface::{DEFAULT_TX_QUEUE_LEN, Iface, iter_all_ifaces},
+        socket::Socket,
+    },
+    prelude::*,
+    util::{
+        ioctl::{RawIoctl, dispatch_ioctl},
+        net::CSocketAddrFamily,
+    },
+};
+
+const IFNAMSIZ: usize = 16;
+
+mod ioctl_defs {
+    use super::{CIfConf, CIfReq};
+    use crate::util::ioctl::{InOutData, ioc};
+
+    // Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/sockios.h#L56>.
+    pub(super) type GetIfName       = ioc!(SIOCGIFNAME,     0x8910, InOutData<CIfReq>);
+    pub(super) type GetIfConf       = ioc!(SIOCGIFCONF,     0x8912, InOutData<CIfConf>);
+    pub(super) type GetIfFlags      = ioc!(SIOCGIFFLAGS,    0x8913, InOutData<CIfReq>);
+    pub(super) type GetIfMetric     = ioc!(SIOCGIFMETRIC,   0x891D, InOutData<CIfReq>);
+    pub(super) type GetIfMtu        = ioc!(SIOCGIFMTU,      0x8921, InOutData<CIfReq>);
+    pub(super) type GetIfHwAddr     = ioc!(SIOCGIFHWADDR,   0x8927, InOutData<CIfReq>);
+    pub(super) type GetIfIndex      = ioc!(SIOCGIFINDEX,    0x8933, InOutData<CIfReq>);
+    pub(super) type GetIfTxQueueLen = ioc!(SIOCGIFTXQLEN,   0x8942, InOutData<CIfReq>);
+}
+
+pub fn socket_ioctl<T: Socket>(socket: &T, raw_ioctl: RawIoctl) -> Result<i32> {
+    // Linux always handles `SIOCGIFCONF` first.
+    match handle_get_ifconf(raw_ioctl) {
+        Err(err) if err.error() == Errno::ENOTTY => (),
+        res => return res,
+    }
+
+    // Each socket handles commands specific to its protocol or socket type.
+    match socket.protocol_ioctl(raw_ioctl) {
+        Err(err) if err.error() == Errno::ENOTTY => {}
+        res => return res,
+    }
+
+    // Handle network device commands.
+    network_device_ioctl(raw_ioctl)
+}
+
+fn handle_get_ifconf(raw_ioctl: RawIoctl) -> Result<i32> {
+    use ioctl_defs::*;
+
+    dispatch_ioctl!(match raw_ioctl {
+        cmd @ GetIfConf => {
+            let mut ifconf = cmd.read()?;
+            ifconf.write_ifreqs()?;
+            cmd.write(&ifconf)?;
+            Ok(0)
+        }
+        _ => return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown"),
+    })
+}
+
+fn network_device_ioctl(raw_ioctl: RawIoctl) -> Result<i32> {
+    use ioctl_defs::*;
+
+    dispatch_ioctl!(match raw_ioctl {
+        cmd @ GetIfName => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_index()?;
+
+            let name = iface.name().to_bytes_with_nul();
+            assert!(name.len() <= IFNAMSIZ);
+            ifreq.name[..name.len()].copy_from_slice(name);
+            ifreq.name[name.len()..].fill(0);
+
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfFlags => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            ifreq.data = CIfReqData::new_flags(iface.flags().bits() as i16);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfMetric => {
+            let mut ifreq = cmd.read()?;
+            ifreq.get_iface_by_name()?;
+            // Linux's per-interface metric is currently unused and always reported as zero.
+            ifreq.data = CIfReqData::new_value(0);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfMtu => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            ifreq.data = CIfReqData::new_mtu(iface.mtu() as i32);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfHwAddr => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            let mut socket_addr = CSocketAddr::new_zeroed();
+            socket_addr.family = iface.type_() as u16;
+            if let Some(address) = iface.ethernet_addr() {
+                socket_addr.data[..6].copy_from_slice(&address.0);
+            }
+            ifreq.data = CIfReqData::new_hardware_addr(socket_addr);
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfIndex => {
+            let mut ifreq = cmd.read()?;
+            let iface = ifreq.get_iface_by_name()?;
+            let index = iface.index();
+            ifreq.data = CIfReqData::new_value(index.cast_signed());
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        cmd @ GetIfTxQueueLen => {
+            let mut ifreq = cmd.read()?;
+            ifreq.get_iface_by_name()?;
+            ifreq.data = CIfReqData::new_value(DEFAULT_TX_QUEUE_LEN.cast_signed());
+            cmd.write(&ifreq)?;
+            Ok(0)
+        }
+        _ => return_errno_with_message!(Errno::ENOTTY, "the socket ioctl command is unknown"),
+    })
+}
+
+/// `struct ifconf` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if.h#L286>.
+#[padding_struct]
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct CIfConf {
+    len: i32,
+    data: Vaddr,
+}
+
+impl CIfConf {
+    fn write_ifreqs(&mut self) -> Result<()> {
+        let ifreqs = iter_all_ifaces().filter_map(|iface| {
+            let name = {
+                let name_bytes = iface.name().to_bytes_with_nul();
+                let name_len = name_bytes.len();
+                assert!(name_len <= IFNAMSIZ);
+
+                let mut name = [0; IFNAMSIZ];
+                name[..name_len].copy_from_slice(name_bytes);
+                name
+            };
+
+            let address = {
+                let ipv4_addr = iface.ipv4_cidr()?.address();
+                CSocketAddr::from(ipv4_addr)
+            };
+
+            Some(CIfReq {
+                name,
+                data: CIfReqData::new_addr(address),
+            })
+        });
+
+        if self.data == 0 {
+            let count = ifreqs.count();
+            self.len = (count * size_of::<CIfReq>()) as i32;
+            return Ok(());
+        }
+        let max_ifreqs = self.len.max(0) as usize / size_of::<CIfReq>();
+        let task = Task::current().unwrap();
+        let user_space = CurrentUserSpace::new(task.as_thread_local().unwrap());
+        let mut writer = user_space.writer(self.data, max_ifreqs * size_of::<CIfReq>())?;
+        let mut count = 0;
+        for ifreq in ifreqs.take(max_ifreqs) {
+            writer.write_val(&ifreq)?;
+            count += 1;
+        }
+        self.len = (count * size_of::<CIfReq>()) as i32;
+        Ok(())
+    }
+}
+
+/// `struct ifreq` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if.h#L234>.
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+pub(in crate::net::socket) struct CIfReq {
+    name: [u8; IFNAMSIZ],
+    data: CIfReqData,
+}
+
+/// The `ifr_ifru` union in `struct ifreq` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if.h#L241>.
+#[pod_union]
+#[repr(C)]
+#[derive(Clone, Copy)]
+union CIfReqData {
+    addr: CSocketAddr,
+    dst_addr: CSocketAddr,
+    broad_addr: CSocketAddr,
+    netmask: CSocketAddr,
+    hardware_addr: CSocketAddr,
+    flags: i16,
+    value: i32,
+    mtu: i32,
+    slave: [u8; IFNAMSIZ],
+    new_name: [u8; IFNAMSIZ],
+    data: Vaddr,
+    settings: CIfSettings,
+}
+
+/// `struct sockaddr` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/linux/socket.h#L36>.
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct CSocketAddr {
+    family: u16,
+    data: [u8; 14],
+}
+
+impl From<Ipv4Address> for CSocketAddr {
+    fn from(address: Ipv4Address) -> Self {
+        let family = CSocketAddrFamily::AF_INET as u16;
+
+        let mut data = [0u8; 14];
+        data[2..6].copy_from_slice(&address.octets());
+
+        Self { family, data }
+    }
+}
+
+/// `struct if_settings` in Linux.
+///
+/// Reference: <https://elixir.bootlin.com/linux/v7.1/source/include/uapi/linux/if.h#L207>.
+#[repr(C)]
+#[derive(Clone, Copy, Pod)]
+struct CIfSettings {
+    type_: u32,
+    size: u32,
+    data: Vaddr,
+}
+
+impl CIfReq {
+    pub(in crate::net::socket) fn set_sockaddr_ipv4(&mut self, address: Ipv4Address) {
+        let socket_addr = CSocketAddr::from(address);
+        self.data = CIfReqData::new_addr(socket_addr);
+    }
+
+    pub(in crate::net::socket) fn get_iface_by_name(&mut self) -> Result<&'static Arc<Iface>> {
+        self.name[IFNAMSIZ - 1] = 0;
+        let name = CStr::from_bytes_until_nul(&self.name).unwrap();
+        iter_all_ifaces()
+            .find(|iface| iface.name() == name)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "no interface found"))
+    }
+
+    fn get_iface_by_index(&self) -> Result<&'static Arc<Iface>> {
+        let index = *self.data.value();
+        iter_all_ifaces()
+            .find(|iface| iface.index().cast_signed() == index)
+            .ok_or_else(|| Error::with_message(Errno::ENODEV, "no interface found"))
+    }
+}

--- a/kernel/src/net/socket/util/mod.rs
+++ b/kernel/src/net/socket/util/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 pub(super) mod datagram_common;
+pub(super) mod ioctl;
 mod linger_option;
 mod message_flags;
 mod message_header;

--- a/kernel/src/util/ioctl/mod.rs
+++ b/kernel/src/util/ioctl/mod.rs
@@ -389,7 +389,6 @@ impl<const MAGIC: u8, const NR: u8, const IS_MODERN: bool, T: Pod>
     Ioctl<MAGIC, NR, IS_MODERN, InOutData<T>>
 {
     /// Reads the ioctl argument from userspace.
-    #[expect(dead_code)]
     pub fn read(&self) -> Result<T> {
         self.with_data_ptr(|ptr| Ok(ptr.read()?))
     }

--- a/test/initramfs/src/regression/network/run_test.sh
+++ b/test/initramfs/src/regression/network/run_test.sh
@@ -23,6 +23,7 @@ sleep 0.2
 ./send_buf_full
 ./sendmmsg
 ./socketpair
+./socket_ioctl
 ./sockoption
 ./sockoption_unix
 ./tcp_err

--- a/test/initramfs/src/regression/network/socket_ioctl.c
+++ b/test/initramfs/src/regression/network/socket_ioctl.c
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MPL-2.0
+
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_arp.h>
+#include <linux/netlink.h>
+#include <linux/sockios.h>
+#include <linux/vm_sockets.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "../common/test.h"
+
+struct socket_info {
+	int domain;
+	int type;
+	int protocol;
+	int fd;
+	bool is_ipv4;
+};
+
+static struct socket_info sockets[] = {
+	{ AF_INET, SOCK_STREAM, 0, -1, true },
+	{ AF_INET, SOCK_DGRAM, 0, -1, true },
+	{ AF_INET6, SOCK_STREAM, 0, -1, false },
+	{ AF_UNIX, SOCK_STREAM, 0, -1, false },
+	{ AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, -1, false },
+	{ AF_VSOCK, SOCK_STREAM, 0, -1, false },
+};
+
+static void init_loopback_ifreq(struct ifreq *ifr)
+{
+	memset(ifr, 0, sizeof(*ifr));
+	strncpy(ifr->ifr_name, "lo", IFNAMSIZ - 1);
+}
+
+static int check_interface(const struct ifreq *ifreqs, int ifreqs_len,
+			   const char *name)
+{
+	for (int offset = 0; offset < ifreqs_len;
+	     offset += sizeof(struct ifreq)) {
+		if (strcmp(ifreqs[offset / sizeof(struct ifreq)].ifr_name,
+			   name) == 0)
+			return 0;
+	}
+
+	errno = ENODEV;
+	return -1;
+}
+
+FN_SETUP(general)
+{
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++) {
+		struct socket_info *socket_info = &sockets[i];
+
+		socket_info->fd =
+			CHECK(socket(socket_info->domain, socket_info->type,
+				     socket_info->protocol));
+	}
+}
+END_SETUP()
+
+FN_TEST(general_interface_queries)
+{
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++) {
+		int fd = sockets[i].fd;
+
+		struct ifreq ifr;
+		init_loopback_ifreq(&ifr);
+		TEST_RES(ioctl(fd, SIOCGIFINDEX, &ifr), ifr.ifr_ifindex > 0);
+		int loopback_index = ifr.ifr_ifindex;
+
+		memset(&ifr, 0, sizeof(ifr));
+		ifr.ifr_ifindex = loopback_index;
+		TEST_RES(ioctl(fd, SIOCGIFNAME, &ifr),
+			 strcmp(ifr.ifr_name, "lo") == 0);
+
+		init_loopback_ifreq(&ifr);
+		TEST_RES(ioctl(fd, SIOCGIFFLAGS, &ifr),
+			 (ifr.ifr_flags &
+			  (IFF_UP | IFF_LOOPBACK | IFF_RUNNING)) ==
+				 (IFF_UP | IFF_LOOPBACK | IFF_RUNNING));
+		TEST_RES(ioctl(fd, SIOCGIFMETRIC, &ifr), ifr.ifr_metric == 0);
+		TEST_RES(ioctl(fd, SIOCGIFMTU, &ifr), ifr.ifr_mtu > 0);
+		TEST_RES(ioctl(fd, SIOCGIFHWADDR, &ifr),
+			 ifr.ifr_hwaddr.sa_family == ARPHRD_LOOPBACK);
+		TEST_RES(ioctl(fd, SIOCGIFTXQLEN, &ifr), ifr.ifr_qlen == 1000);
+
+		memset(&ifr, 0, sizeof(ifr));
+		strncpy(ifr.ifr_name, "missing", IFNAMSIZ - 1);
+		TEST_ERRNO(ioctl(fd, SIOCGIFINDEX, &ifr), ENODEV);
+		memset(&ifr, 0, sizeof(ifr));
+		ifr.ifr_ifindex = 0;
+		TEST_ERRNO(ioctl(fd, SIOCGIFNAME, &ifr), ENODEV);
+
+		memset(&ifr, 'x', sizeof(ifr));
+		TEST_ERRNO(ioctl(fd, SIOCGIFINDEX, &ifr), ENODEV);
+	}
+}
+END_TEST()
+
+FN_TEST(interface_conf)
+{
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++) {
+		int fd = sockets[i].fd;
+
+		struct ifconf ifc = { .ifc_len = 0, .ifc_buf = NULL };
+		TEST_RES(ioctl(fd, SIOCGIFCONF, &ifc),
+			 ifc.ifc_len >= (int)sizeof(struct ifreq));
+
+		int capacity = ifc.ifc_len;
+		struct ifreq *ifreqs =
+			TEST_RES(calloc(1, capacity), _ret != NULL);
+		ifc.ifc_len = capacity;
+		ifc.ifc_buf = (char *)ifreqs;
+		TEST_RES(ioctl(fd, SIOCGIFCONF, &ifc),
+			 ifc.ifc_len >= (int)sizeof(struct ifreq));
+		TEST_SUCC(check_interface(ifreqs, ifc.ifc_len, "lo"));
+		free(ifreqs);
+	}
+}
+END_TEST()
+
+FN_TEST(ipv4_interface_queries)
+{
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++) {
+		if (!sockets[i].is_ipv4)
+			continue;
+
+		int fd = sockets[i].fd;
+		struct ifreq ifr;
+		init_loopback_ifreq(&ifr);
+		TEST_RES(ioctl(fd, SIOCGIFADDR, &ifr),
+			 ifr.ifr_addr.sa_family == AF_INET &&
+				 ((struct sockaddr_in *)&ifr.ifr_addr)
+						 ->sin_addr.s_addr ==
+					 htonl(INADDR_LOOPBACK));
+		TEST_SUCC(ioctl(fd, SIOCGIFDSTADDR, &ifr));
+		TEST_RES(ioctl(fd, SIOCGIFBRDADDR, &ifr),
+			 ((struct sockaddr_in *)&ifr.ifr_broadaddr)
+					 ->sin_addr.s_addr == 0);
+		TEST_RES(ioctl(fd, SIOCGIFNETMASK, &ifr),
+			 ((struct sockaddr_in *)&ifr.ifr_netmask)
+					 ->sin_addr.s_addr ==
+				 htonl(0xff000000));
+	}
+}
+END_TEST()
+
+FN_TEST(non_ipv4_interface_queries)
+{
+	unsigned long ipv4_only_requests[] = {
+		SIOCGIFADDR,
+		SIOCGIFDSTADDR,
+		SIOCGIFBRDADDR,
+		SIOCGIFNETMASK,
+	};
+
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++) {
+		if (sockets[i].is_ipv4)
+			continue;
+
+		for (size_t j = 0; j < sizeof(ipv4_only_requests) /
+					       sizeof(ipv4_only_requests[0]);
+		     j++) {
+			struct ifreq ifr;
+			init_loopback_ifreq(&ifr);
+			TEST_ERRNO(ioctl(sockets[i].fd, ipv4_only_requests[j],
+					 &ifr),
+				   ENOTTY);
+		}
+	}
+}
+END_TEST()
+
+FN_SETUP(cleanup)
+{
+	for (size_t i = 0; i < sizeof(sockets) / sizeof(sockets[0]); i++)
+		CHECK(close(sockets[i].fd));
+}
+END_SETUP()


### PR DESCRIPTION
This PR implements support for socket ioctl. It also adds support for some commonly used ioctl commands related to querying network settings.

### Regarding the relationship with #3513

Since #3513 has been unresponsive for a long time, I don't think it's realistic to expect that work to continue. Initially, I added the author of #3513 as a co-author in my commit message, since I originally referenced their implementation. However, as I worked on this further, I found that the original implementation was largely incorrect, so I removed the co-author attribution in the latest commit.

### Design

The current ioctl implementation follows Linux's approach, using a layered dispatch mechanism. The core logic is shown below. For all socket types, `SIOCGIFCONF` (used to retrieve information about all interfaces) is handled first. Next, each socket implements its own `protocol_ioctl` to handle commands specific to that socket. Finally, `network_device_ioctl` handles device-related commands, which, like `SIOCGIFCONF`, applies to all socket types.

```rust
pub fn socket_ioctl<T: Socket>(socket: &T, raw_ioctl: RawIoctl) -> Result<i32> {
    // Linux always handles `SIOCGIFCONF` first.
    match handle_get_ifconf(raw_ioctl) {
        Err(err) if err.error() == Errno::ENOTTY => (),
        res => return res,
    }

    // Each socket handles commands specific to its protocol or socket type.
    match socket.protocol_ioctl(raw_ioctl) {
        Err(err) if err.error() == Errno::ENOTTY => {}
        res => return res,
    }

    // Handle network device commands.
    network_device_ioctl(raw_ioctl)
}
```

For `protocol_ioctl`, each socket can provide its own implementation, which may itself involve further layering. For example, for a TCP socket, IP-layer-common ioctl commands are handled first, followed by commands that require TCP-specific handling — such as FIONREAD. Due to the scope of this PR, support for `ipv6_ioctl` and `FIONREAD` has not been included yet — only `ipv4_ioctl` support has been added.

```rust
impl SocketPrivate for StreamSocket {
    fn protocol_ioctl(&self, raw_ioctl: RawIoctl) -> Result<i32> {
        // Handle common IPv4/IPv6 ioctl commands.
        match self.family {
            IpAddressFamily::IPv4 => ipv4_ioctl(raw_ioctl),
            IpAddressFamily::IPv6 => ipv6_ioctl(raw_ioctl),
        }

        // Handle ioctl commands that require TCP-specific handling.
        dispatch_ioctl!(match raw_ioctl {
           cmd @ FIONREAD => { todo!() }
       }
}
```

The first commit is a relatively small refactoring that moves `IpAddrFamily` from `InitStream` to `StreamSocket`, since `protocol_ioctl` needs to dispatch to the appropriate common IP-layer ioctl handler based on the address family.